### PR TITLE
Update Set_up_bastion_and_iscsi_host.md

### DIFF
--- a/docs/Set_up_bastion_and_iscsi_host.md
+++ b/docs/Set_up_bastion_and_iscsi_host.md
@@ -192,7 +192,7 @@ First, we need a valid AMI in this AWS region:
 And now we can create the jumphost with a public IP and tag it accordingly
 
 ```bash
-<laptop>$ aws ec2 run-instances --image-id $AMI --count 1 --instance-type  t2.medium --key-name iscsi-demo --security-group-ids $SG_PUB --subnet-id NET_PUB  --associate-public-ip-address
+<laptop>$ aws ec2 run-instances --image-id $AMI --count 1 --instance-type  t2.medium --key-name iscsi-demo --security-group-ids $SG_PUB --subnet-id $NET_PUB  --associate-public-ip-address
 {
     "Groups": [],
     "Instances": [


### PR DESCRIPTION
Adding a missing "$" for the NET_PUB variable for the command: 

<laptop>$ aws ec2 run-instances --image-id $AMI --count 1 --instance-type  t2.medium --key-name iscsi-demo --security-group-ids $SG_PUB --subnet-id NET_PUB  --associate-public-ip-address

Under the ## bastion / jumphost section